### PR TITLE
Add redirect for /api

### DIFF
--- a/redirects/miscellaneous.js
+++ b/redirects/miscellaneous.js
@@ -39,6 +39,11 @@ const miscellaneousRedirects = [
     destination: '/',
     permanent: true,
   },
+  {
+    source: '/api',
+    destination: 'https://api.tutorcruncher.com/',
+    permanent: true,
+  },
 ]
 
 module.exports = miscellaneousRedirects;


### PR DESCRIPTION
* Few instances of people writing in about the api docs, so adding in a redirect from `/api` -> `https://api.tutorcruncher.com/`
