### PR TITLE
Remove solutions/ page from sitemap as it doesn't exist

### DIFF
--- a/src/app/(default)/sitemap/page.tsx
+++ b/src/app/(default)/sitemap/page.tsx
@@ -46,7 +46,11 @@ function renderEntries(entries) {
     <li key={entry.parent ? entry.parent.title : entry.title}>
       {entry.children ? (
         <>
-          <Link href={entry.parent.url}>{entry.parent.title}</Link>
+          {entry.parent.url ? (
+            <Link href={entry.parent.url}>{entry.parent.title}</Link>
+          ) : (
+            entry.parent.title
+          )}
           <ul>{renderEntries(entry.children)}</ul>
         </>
       ) : (
@@ -80,8 +84,11 @@ export default async function sitemap() {
     ...landingPages,
     // @ts-expect-error - pages nested with no parent
     ...formatEntries(pages, null, (doc) => `${doc.uid}`),
-    // @ts-expect-error - pages nested with no parent
-    ...formatEntries(solutions, null, (doc) => `solutions/${doc.uid}`),
+    formatEntries(
+      solutions,
+      { title: "Solutions", url: null },
+      (doc) => `solutions/${doc.uid}`
+    ),
     formatEntries(
       features,
       { title: "Features", url: "/features" },

--- a/src/app/(default)/sitemap/page.tsx
+++ b/src/app/(default)/sitemap/page.tsx
@@ -80,11 +80,8 @@ export default async function sitemap() {
     ...landingPages,
     // @ts-expect-error - pages nested with no parent
     ...formatEntries(pages, null, (doc) => `${doc.uid}`),
-    formatEntries(
-      solutions,
-      { title: "Solutions", url: "/solutions" },
-      (doc) => `solutions/${doc.uid}`
-    ),
+    // @ts-expect-error - pages nested with no parent
+    ...formatEntries(solutions, null, (doc) => `solutions/${doc.uid}`),
     formatEntries(
       features,
       { title: "Features", url: "/features" },


### PR DESCRIPTION
* Edits the `renderEntries` so that the sitemap can have a header that doesn't contain a URL for scenarios where we have pages like solutions/payg, solutions/enterprise etc but with no base solutions/ page