### PR TITLE
Remove old redirect

### DIFF
--- a/redirects/blog.js
+++ b/redirects/blog.js
@@ -49,7 +49,7 @@ const blogRedirects = [
   },
   {
     source: '/starting-tutor-business/how-to-structure-a-tutoring-session',
-    destination: '/blog/how-to-structure-a-tutoring-session-in-7-easy-steps',
+    destination: '/blog/how-to-structure-a-tutoring-session',
     permanent: true,
     statusCode: 301,
   },
@@ -678,12 +678,6 @@ const blogRedirects = [
     statusCode: 301,
   },
   {
-    source: '/blog/how-to-structure-a-tutoring-session',
-    destination: '/blog/how-to-structure-a-tutoring-session-in-7-easy-steps',
-    permanent: true,
-    statusCode: 301,
-  },
-    {
     source: '/blog/online-teaching-skills',
     destination: '/blog/7-online-teaching-skills-worth-developing',
     permanent: true,


### PR DESCRIPTION
Removing an old redirect so that it points to the URL mentioned in the email below
<img width="1361" height="232" alt="image" src="https://github.com/user-attachments/assets/dff0e33b-5930-4505-9db2-f2db87990f11" />

Can see now the page has the URL we want:
<img width="1731" height="1039" alt="image" src="https://github.com/user-attachments/assets/91a50b05-ddfc-4bdb-b719-86b5c897ec6f" />
