### PR TITLE
Fix canonical urls on pricing-calculator page

### DIFF
--- a/src/app/(default)/pricing-calculator/[uid]/page.tsx
+++ b/src/app/(default)/pricing-calculator/[uid]/page.tsx
@@ -10,7 +10,7 @@ import { formatMetaData } from "@/helpers/metaData";
 export async function generateMetadata({ params }): Promise<Metadata> {
   try {
     const { meta } = await fetchPricingPageByUid(params.uid);
-    const url = `https://tutorcruncher.com/pricing-calculator`;
+    const url = `https://tutorcruncher.com/pricing-calculator/${params.uid}`;
 
     const title = `Pricing Calculator ${params.uid.toUpperCase()} | TutorCruncher`;
     return formatMetaData(title, meta.description, url);


### PR DESCRIPTION
Fixes the canonical urls in the head of the page so that they don't point to 404s as requested by the SEO team.

<img width="1749" height="455" alt="image" src="https://github.com/user-attachments/assets/f187bc7d-6d29-4573-907c-d3cc5a7c73f2" />


Before:
<img width="519" height="49" alt="image" src="https://github.com/user-attachments/assets/ae4cb230-f409-4273-9716-79b54a1946f2" />

After:
<img width="519" height="49" alt="image" src="https://github.com/user-attachments/assets/bd62128e-7a0f-4e31-9673-8f5b6fc41f15" />
