### PR TITLE
Agent readiness: discovery files, JSON-LD, OpenAPI mirror, agents.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# website-new
+# tutorcruncher-website
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/38a77df5-c3ea-4a74-8d5b-d39d74e72f39/deploy-status)](https://app.netlify.com/projects/tutorcruncher/deploys)
 
 This is the repository for the TutorCruncher website, built using [Next.js](https://nextjs.org/) and integrated with [Prismic](https://prismic.io/) for content management.
 
@@ -14,8 +16,8 @@ This is the repository for the TutorCruncher website, built using [Next.js](http
 To get started with the project, clone the repository and install the dependencies:
 
 ```bash
-git clone https://github.com/your-username/website-new.git
-cd website-new
+git clone https://github.com/tutorcruncher/tutorcruncher-website.git
+cd tutorcruncher-website
 npm install
 ```
 

--- a/next.config.js
+++ b/next.config.js
@@ -38,6 +38,14 @@ const nextConfig = {
   async redirects() {
     return [...integrationsRedirects, ...blogRedirects, ...miscellaneousRedirects];
   },
+  async rewrites() {
+    return [
+      {
+        source: "/.well-known/openapi.yaml",
+        destination: "https://secure.tutorcruncher.com/api/schema/",
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/public/.well-known/agents.json
+++ b/public/.well-known/agents.json
@@ -1,0 +1,158 @@
+{
+  "agentsJson": "0.1.0",
+  "info": {
+    "title": "TutorCruncher API — Agent Contracts",
+    "version": "0.1.0",
+    "description": "Agent-facing contracts for the TutorCruncher REST API. All operations require Bearer-token authentication (Authorization: Token <api_key>) and are automatically scoped to the Integration's Branch (tenant). The flows declared below are the read-only operations that are safe for autonomous agents to invoke. Mutating operations (create/update/destroy) are documented in the OpenAPI source but are intentionally NOT pre-approved as agent flows — they should require explicit per-tenant user consent."
+  },
+  "sources": [
+    {
+      "id": "tutorcruncher",
+      "path": "https://tutorcruncher.com/.well-known/openapi.yaml",
+      "description": "TutorCruncher REST API OpenAPI 3 specification (proxied from secure.tutorcruncher.com/api/schema/)."
+    }
+  ],
+  "overrides": [],
+  "flows": [
+    {
+      "id": "list_appointments",
+      "title": "List lessons",
+      "description": "List the authenticated Integration's lessons (appointments). Read-only.",
+      "actions": [
+        {
+          "id": "list_appointments_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "appointments_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "get_appointment",
+      "title": "Get a lesson",
+      "description": "Retrieve a single lesson by id. Read-only.",
+      "actions": [
+        {
+          "id": "get_appointment_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "appointments_retrieve"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_services",
+      "title": "List services",
+      "description": "List services (jobs) in the agency. Read-only.",
+      "actions": [
+        {
+          "id": "list_services_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "services_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_clients",
+      "title": "List clients",
+      "description": "List clients (parents/companies) for the authenticated branch. Read-only.",
+      "actions": [
+        {
+          "id": "list_clients_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "clients_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "get_client",
+      "title": "Get a client",
+      "description": "Retrieve a single client by id. Read-only.",
+      "actions": [
+        {
+          "id": "get_client_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "clients_retrieve"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_contractors",
+      "title": "List contractors",
+      "description": "List contractors (tutors) for the authenticated branch. Read-only.",
+      "actions": [
+        {
+          "id": "list_contractors_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "contractors_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_recipients",
+      "title": "List students",
+      "description": "List recipients (students) for the authenticated branch. Read-only.",
+      "actions": [
+        {
+          "id": "list_recipients_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "recipients_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_invoices",
+      "title": "List invoices",
+      "description": "List invoices for the authenticated branch. Read-only.",
+      "actions": [
+        {
+          "id": "list_invoices_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "invoices_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "list_payment_orders",
+      "title": "List payment orders",
+      "description": "List payment orders (contractor payouts) for the authenticated branch. Read-only.",
+      "actions": [
+        {
+          "id": "list_payment_orders_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "payment_orders_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    },
+    {
+      "id": "get_branch",
+      "title": "Get branch configuration",
+      "description": "Read the authenticated Branch's configuration (currency, region, branding). Read-only.",
+      "actions": [
+        {
+          "id": "get_branch_action",
+          "sourceId": "tutorcruncher",
+          "operationId": "branch_list"
+        }
+      ],
+      "links": [],
+      "fields": { "parameters": [], "requestBody": {} }
+    }
+  ]
+}

--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "TutorCruncher",
+  "name_for_model": "tutorcruncher",
+  "description_for_human": "TutorCruncher is business-management software for tutoring, coaching and teaching agencies. It handles scheduling, invoicing, payments, CRM, contractor management, integrations with Stripe and GoCardless, and a public REST API.",
+  "description_for_model": "TutorCruncher is a multi-tenant SaaS for tutoring agencies. Use the OpenAPI specification to read or modify clients, contractors, students, lessons, services, invoices, payment orders, ad-hoc charges, payments, reviews, and integrations. Authenticate by sending the header `Authorization: Token <api_key>`, where the API key is provisioned per Integration in the agency's Settings > API. The API enforces per-branch (tenant) scoping; every authenticated request is scoped to a single Branch.",
+  "auth": {
+    "type": "service_http",
+    "authorization_type": "bearer"
+  },
+  "api": {
+    "type": "openapi",
+    "url": "https://secure.tutorcruncher.com/api/schema/"
+  },
+  "logo_url": "https://tutorcruncher.com/logo_full.png",
+  "contact_email": "support@tutorcruncher.com",
+  "legal_info_url": "https://tutorcruncher.com/privacy-policy"
+}

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:support@tutorcruncher.com
+Expires: 2027-05-15T23:59:59.000Z
+Preferred-Languages: en
+Canonical: https://tutorcruncher.com/.well-known/security.txt
+Policy: https://tutorcruncher.com/privacy-policy

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,79 @@
+# TutorCruncher — Full Reference
+
+TutorCruncher is a business-management platform built specifically for tutoring agencies, coaching companies and education providers. It replaces a patchwork of spreadsheets, calendars, billing tools and CRMs with a single multi-tenant web application. The platform has been in continuous development since 2014 and is used by agencies across the UK, US, Australia, Canada, New Zealand and beyond.
+
+## What it does
+
+- **Scheduling**: book one-to-one and group lessons, set tutor availability, send reminders, run recurring lesson series, manage cancellations.
+- **CRM**: store clients (parents/companies), contractors (tutors), students (service recipients) and agents (affiliates) with custom fields, labels, and a configurable sales pipeline.
+- **Invoicing & payments**: generate invoices and proforma invoices automatically from lessons, accept card payments via Stripe (Standard or Connect), accept direct debit via GoCardless, handle multi-currency, run payouts to contractors, reconcile via Xero/QuickBooks.
+- **Reporting**: financial reports, contractor pay reports, client statements, lesson reports, custom exports, BigQuery export for advanced analytics.
+- **Communication**: branded email templates, SMS notifications, broadcasts, automated reminders.
+- **Public-facing**: a tutor-discovery website ("Socket") that agencies can embed, plus public profiles and an enquiry form.
+- **API & integrations**: a documented REST API, webhooks (via the Chronos service), Zapier, and direct integrations with Stripe, GoCardless, Xero, QuickBooks, Mailchimp, Zoom, Daily.co, Lessonspace.
+
+## Pricing tiers
+
+TutorCruncher offers three tiers. All tiers include unlimited users, unlimited lessons, all features, and standard support.
+
+1. **Pay-as-you-go (PAYG)** — low monthly base, charged per completed lesson. Best for new or low-volume agencies.
+2. **Startup** — higher monthly base, fewer per-lesson fees. Best for established agencies running 100+ lessons/month.
+3. **Enterprise** — flat fee for very large agencies. Includes dedicated account management.
+
+Per-lesson and payment-processing fees vary by region and currency. See https://tutorcruncher.com/pricing for live numbers and https://tutorcruncher.com/pricing-calculator for an interactive estimate.
+
+## API
+
+The REST API at `https://secure.tutorcruncher.com/api/` exposes nearly every resource in the system:
+
+- `/api/appointments/` — lessons (create, list, update, cancel)
+- `/api/services/` — services / jobs
+- `/api/clients/`, `/api/contractors/`, `/api/recipients/`, `/api/agents/` — the four role types
+- `/api/invoices/`, `/api/proforma-invoices/`, `/api/payment-orders/` — billing
+- `/api/adhoccharges/`, `/api/ahc-categories/` — ad-hoc charges
+- `/api/balance-updates/` — manual balance adjustments
+- `/api/reports/`, `/api/reviews/`, `/api/tasks/`, `/api/notes/`, `/api/labels/` — supporting resources
+- `/api/branch/`, `/api/integration/` — agency configuration
+- `/api/enquiry/` — public enquiry submission (used by Socket and external tutor sites)
+- `/api/webhook/` — webhook activation/deactivation
+
+Authentication is per-Integration. Generate an API key in the agency's Settings > API > Integrations, then include `Authorization: Token <api_key>` on every request. Each integration is scoped to one Branch (tenant).
+
+The full machine-readable schema lives at `https://secure.tutorcruncher.com/api/schema/`. Interactive Swagger UI is at `/api/docs/` and ReDoc is at `/api/redoc/`.
+
+Webhooks are delivered via the Chronos service and signed with HMAC-SHA256 using the integration's API key (sent in the `Webhook-Signature` header). Webhook events fire on create/update/delete of all major resources.
+
+## Integrations
+
+- **Payments**: Stripe (Standard accounts, Connect, GBP/USD/EUR/AUD/CAD/NZD/SEK), GoCardless (UK, EU, AU, NZ direct debit), bank transfer
+- **Accounting**: Xero, QuickBooks Online
+- **Marketing/comms**: Mailchimp Transactional (Mandrill), Intercom, Zapier (1000+ apps)
+- **Video**: Zoom, Daily.co, Lessonspace, Microsoft Teams
+- **SSO**: Google, Apple
+- **Calendar**: Google Calendar, iCal feeds
+
+## Multi-tenancy
+
+Every account ("Agency") has one or more Branches. Branches are the unit of tenant isolation: data, settings, branding, currencies, payment processors, and users are all scoped to a single Branch. The API enforces this — every authenticated request is automatically filtered to the requesting Integration's Branch.
+
+## Compliance and security
+
+- GDPR-compliant: data residency in EU/UK on request, full data export and erasure tools
+- PCI compliance handled via Stripe (no card numbers ever touch TutorCruncher servers)
+- Optional SSO (Google, Apple) and 2FA via authenticator apps
+- Audit log (Action history) on every meaningful action
+
+## Support and contact
+
+- Email: support@tutorcruncher.com
+- Help centre: https://help.tutorcruncher.com (linked from in-product help icons)
+- Book a demo: https://tutorcruncher.com/book-a-call
+- Status: monitored internally; outages reported via in-app banners and email
+
+## Where to read more
+
+- Marketing site: https://tutorcruncher.com
+- App: https://secure.tutorcruncher.com
+- API docs: https://secure.tutorcruncher.com/api/docs/
+- Privacy policy: https://tutorcruncher.com/privacy-policy
+- Sitemap: https://tutorcruncher.com/sitemap.xml

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,47 @@
+# TutorCruncher
+
+> TutorCruncher is business-management software for tutoring, coaching and teaching agencies. It handles scheduling, invoicing, payments, CRM, contractor management, and integrations. Used by hundreds of agencies in 30+ countries.
+
+## Key information
+
+- **Industry**: Education / EdTech / SaaS
+- **Customers**: Tutoring agencies, coaching businesses, education providers
+- **Geographies**: UK, US, Australia, Canada, New Zealand, Ireland, and more
+- **Pricing model**: Pay-as-you-go (per-lesson fee), Startup, Enterprise tiers — see /pricing
+- **Auth integrations**: Email, Google, Apple
+- **Payment integrations**: Stripe, GoCardless
+- **Other integrations**: Xero, QuickBooks, Mailchimp, Zapier, Zoom, Daily.co, Lessonspace
+
+## Product
+
+- [Features](https://tutorcruncher.com/features) — overview of every feature
+- [Integrations](https://tutorcruncher.com/integrations) — full integration catalogue
+- [Solutions](https://tutorcruncher.com/solutions) — by use case
+- [Pricing](https://tutorcruncher.com/pricing) — tiers, fees, calculator
+- [Pricing calculator](https://tutorcruncher.com/pricing-calculator) — interactive estimate
+- [Reviews](https://tutorcruncher.com/reviews) — customer testimonials
+- [Blog](https://tutorcruncher.com/blog) — articles and product updates
+
+## Developer / API
+
+- [API documentation (Swagger UI)](https://secure.tutorcruncher.com/api/docs/) — interactive API reference
+- [API documentation (ReDoc)](https://secure.tutorcruncher.com/api/redoc/) — alternative reference layout
+- [OpenAPI 3 schema](https://secure.tutorcruncher.com/api/schema/) — machine-readable specification
+- [AI plugin manifest](https://tutorcruncher.com/.well-known/ai-plugin.json)
+
+The REST API exposes appointments (lessons), services (jobs), clients, contractors, students (service recipients), agents, invoices, payment orders, ad-hoc charges, balance updates, reports, and more. Authentication is per-Integration via `Authorization: Token <api_key>`.
+
+## Company
+
+- [Contact us](https://tutorcruncher.com/contact)
+- [Book a demo call](https://tutorcruncher.com/book-a-call)
+- Support: support@tutorcruncher.com
+
+## Legal
+
+- [Privacy policy](https://tutorcruncher.com/privacy-policy)
+- [Terms and conditions](https://tutorcruncher.com/user-terms-and-conditions.txt)
+
+## Sitemap
+
+Full URL list: https://tutorcruncher.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -6,4 +6,42 @@ Disallow: /tutoring-online/
 Disallow: /us/blog/
 Disallow: /gb/blog/
 
+# AI / LLM crawlers — explicit allow so model-training and answer-engine bots
+# can index our marketing pages and discover the API spec at /.well-known/ai-plugin.json
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
 Sitemap: https://tutorcruncher.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,60 +9,29 @@ Disallow: /gb/blog/
 # AI / LLM crawlers — explicit allow so model-training and answer-engine bots
 # can index our marketing pages and discover the API spec at /.well-known/ai-plugin.json
 User-agent: GPTBot
-Allow: /
-
 User-agent: ChatGPT-User
-Allow: /
-
 User-agent: OAI-SearchBot
-Allow: /
-
 User-agent: ClaudeBot
-Allow: /
-
 User-agent: Claude-Web
-Allow: /
-
 User-agent: anthropic-ai
-Allow: /
-
 User-agent: PerplexityBot
-Allow: /
-
 User-agent: Perplexity-User
-Allow: /
-
 User-agent: Google-Extended
-Allow: /
-
 User-agent: Applebot-Extended
-Allow: /
-
-User-agent: Bytespider
-Allow: /
-
-User-agent: CCBot
-Allow: /
-
 User-agent: Applebot
-Allow: /
-
-User-agent: Meta-ExternalAgent
-Allow: /
-
-User-agent: FacebookBot
-Allow: /
-
-User-agent: Amazonbot
-Allow: /
-
-User-agent: cohere-ai
-Allow: /
-
-User-agent: Diffbot
-Allow: /
-
 User-agent: Bingbot
+User-agent: Meta-ExternalAgent
+User-agent: FacebookBot
+User-agent: Bytespider
+User-agent: CCBot
+User-agent: Amazonbot
+User-agent: cohere-ai
+User-agent: Diffbot
+Disallow: /api/
+Disallow: /_next/
+Disallow: /tutoring-online/
+Disallow: /us/blog/
+Disallow: /gb/blog/
 Allow: /
 
 Sitemap: https://tutorcruncher.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -44,4 +44,25 @@ Allow: /
 User-agent: CCBot
 Allow: /
 
+User-agent: Applebot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: FacebookBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: Diffbot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
 Sitemap: https://tutorcruncher.com/sitemap.xml

--- a/src/app/(default)/layout.tsx
+++ b/src/app/(default)/layout.tsx
@@ -11,6 +11,7 @@ import IntercomClientComponent from "@/components/intercom/intercom";
 import CookieConsentBanner from "@/components/cookie-consent-banner";
 import Image from "next/image";
 import Script from "next/script";
+import { organizationSchema } from "@/schema/structured-data";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -20,6 +21,15 @@ export default async function RootLayout({ children }) {
       <head>
         <link rel="stylesheet" href="https://use.typekit.net/mnd5til.css" />
         <link rel="icon" href="/favicon.ico" sizes="any" />
+        <link
+          rel="describedby"
+          type="application/json"
+          href="/.well-known/ai-plugin.json"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+        />
       </head>
       <GoogleTagManager gtmId={process.env.NEXT_PUBLIC_GTM_ID} />
       <body>

--- a/src/app/(default)/layout.tsx
+++ b/src/app/(default)/layout.tsx
@@ -26,6 +26,12 @@ export default async function RootLayout({ children }) {
           type="application/json"
           href="/.well-known/ai-plugin.json"
         />
+        <link
+          rel="alternate"
+          type="text/plain"
+          href="/llms.txt"
+          title="LLM-readable site summary"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -7,6 +7,7 @@ import { ReadyToGetStarted } from "@/components/features/ready-to-get-started";
 import { formatMetaData } from "@/helpers/metaData";
 import { fetchHomePage } from "@/lib/prismic/home";
 import { RenderSchemas } from "@/components/schema";
+import { softwareApplicationSchema } from "@/schema/structured-data";
 
 export async function generateMetadata(): Promise<Metadata> {
   const { meta } = await fetchHomePage();
@@ -21,7 +22,9 @@ export default async function Index() {
 
   return (
     <>
-      <RenderSchemas schemas={schemas} />
+      <RenderSchemas
+        schemas={[softwareApplicationSchema, ...(schemas ?? [])]}
+      />
       <HomePageHero heading={heading} intro={intro} heroImages={heroImages} />
       <SliceZone slices={slices} components={components} />
       <ReadyToGetStarted />

--- a/src/app/(default)/pricing/[uid]/page.tsx
+++ b/src/app/(default)/pricing/[uid]/page.tsx
@@ -5,6 +5,7 @@ import { Hero } from "@/components/ui/hero";
 import { formatMetaData } from "@/helpers/metaData";
 import { fetchPricingPageByUid } from "@/lib/prismic/pricing";
 import { RenderSchemas } from "@/components/schema";
+import { buildProductSchema } from "@/schema/structured-data";
 import { SliceZone } from "@prismicio/react";
 import { components } from "slices";
 import { notFound } from "next/navigation";
@@ -26,9 +27,29 @@ const PricingPage = async ({ params }) => {
       params.uid
     );
     const region = params.uid;
+    const productSchema = buildProductSchema(region, pricing.currency, [
+      {
+        name: "Pay-as-you-go",
+        basePrice: pricing.payg.base_price,
+        description:
+          "Low monthly base plus a per-completed-lesson fee. Best for new or low-volume agencies.",
+      },
+      {
+        name: "Startup",
+        basePrice: pricing.startup.base_price,
+        description:
+          "Higher monthly base with reduced per-lesson fees. Best for established agencies running 100+ lessons per month.",
+      },
+      {
+        name: "Enterprise",
+        basePrice: pricing.enterprise.base_price,
+        description:
+          "Flat fee for very large agencies. Includes dedicated account management.",
+      },
+    ]);
     return (
       <>
-        <RenderSchemas schemas={schemas} />
+        <RenderSchemas schemas={[productSchema, ...(schemas ?? [])]} />
         <Hero heading={heading} headingVariant="div" />
         <PricingTiers region={region} pricing={pricing} />
         <SliceZone slices={slices} components={components} />

--- a/src/schema/structured-data.ts
+++ b/src/schema/structured-data.ts
@@ -1,0 +1,107 @@
+// Static JSON-LD structured data builders. These complement the per-page schemas
+// editable in Prismic by emitting baseline Organization / SoftwareApplication / Product
+// data that doesn't change page-to-page and shouldn't depend on a CMS round-trip.
+
+const SITE_URL = "https://tutorcruncher.com";
+
+export const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": `${SITE_URL}/#organization`,
+  name: "TutorCruncher",
+  legalName: "TutorCruncher Limited",
+  url: SITE_URL,
+  logo: `${SITE_URL}/logo_full.png`,
+  email: "support@tutorcruncher.com",
+  description:
+    "TutorCruncher is business-management software for tutoring, coaching and teaching agencies. It handles scheduling, invoicing, payments, CRM, contractor management and integrations.",
+  foundingDate: "2014",
+  sameAs: [
+    "https://www.linkedin.com/company/tutorcruncher/",
+    "https://x.com/TutorCruncher",
+    "https://www.facebook.com/tutorcruncher",
+    "https://www.instagram.com/tutorcruncher/",
+    "https://www.youtube.com/@tutorcruncher",
+  ],
+  contactPoint: {
+    "@type": "ContactPoint",
+    contactType: "customer support",
+    email: "support@tutorcruncher.com",
+    url: `${SITE_URL}/contact`,
+    availableLanguage: ["English"],
+  },
+};
+
+export const softwareApplicationSchema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": `${SITE_URL}/#software`,
+  name: "TutorCruncher",
+  url: SITE_URL,
+  applicationCategory: "BusinessApplication",
+  applicationSubCategory: "Education Management",
+  operatingSystem: "Web",
+  description:
+    "All-in-one business management platform for tutoring agencies: scheduling, CRM, invoicing, payment processing, contractor management and a documented REST API.",
+  publisher: { "@id": `${SITE_URL}/#organization` },
+  offers: {
+    "@type": "AggregateOffer",
+    priceCurrency: "GBP",
+    lowPrice: "0",
+    offerCount: "3",
+    url: `${SITE_URL}/pricing`,
+  },
+  featureList: [
+    "Lesson scheduling and calendar management",
+    "Multi-currency invoicing and proforma invoices",
+    "Card payments via Stripe",
+    "Direct debit via GoCardless",
+    "Contractor (tutor) pay management",
+    "CRM with custom fields and pipeline stages",
+    "Public REST API with OpenAPI specification",
+    "Webhooks for external integrations",
+    "Xero and QuickBooks accounting sync",
+    "Zapier and 1000+ app integrations",
+    "Branded email and SMS communications",
+  ],
+};
+
+interface PricingTierData {
+  name: string;
+  basePrice: number | string | null | undefined;
+  description: string;
+}
+
+export function buildProductSchema(
+  region: string,
+  currency: string | null | undefined,
+  tiers: PricingTierData[],
+) {
+  const priceCurrency = (currency ?? "GBP").toUpperCase();
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: `TutorCruncher (${region.toUpperCase()})`,
+    description:
+      "Business-management software for tutoring agencies. Three tiers — Pay-as-you-go, Startup and Enterprise — with unlimited users and unlimited lessons on every tier.",
+    brand: { "@id": `${SITE_URL}/#organization` },
+    url: `${SITE_URL}/pricing/${region}`,
+    offers: tiers
+      .filter((t) => t.basePrice != null && t.basePrice !== "")
+      .map((tier) => ({
+        "@type": "Offer",
+        name: tier.name,
+        description: tier.description,
+        price: String(tier.basePrice),
+        priceCurrency,
+        priceSpecification: {
+          "@type": "UnitPriceSpecification",
+          price: String(tier.basePrice),
+          priceCurrency,
+          unitText: "MONTH",
+        },
+        availability: "https://schema.org/InStock",
+        url: `${SITE_URL}/pricing/${region}`,
+      })),
+  };
+}


### PR DESCRIPTION
## Summary

Makes the marketing site discoverable and machine-readable to agent crawlers / answer engines (ChatGPT, Claude, Perplexity, Google AI Overviews, Ora, etc.), in two commits:

- **`f5d80bd`** — initial discovery files + JSON-LD (Organization, SoftwareApplication, Product/Offer).
- **`0498f79`** — apex-domain OpenAPI mirror, Wild Card AI `agents.json`, `security.txt`, more bots in `robots.txt`, `<link rel=alternate>` for `llms.txt`.

Pairs with TutorCruncher2 PR #16351.

---

## Commit 1 — Discovery files + JSON-LD

### Static files (`public/`)
- **`public/.well-known/ai-plugin.json`** — OpenAI-style plugin manifest pointing at `https://secure.tutorcruncher.com/api/schema/`.
- **`public/llms.txt`** — short curated markdown index (features, integrations, pricing, API docs, contact, legal). Read by Anthropic / OpenAI / Perplexity crawlers.
- **`public/llms-full.txt`** — longer prose reference: what TutorCruncher is, what it does, pricing tiers, full API surface, integrations, multi-tenancy, compliance.
- **`public/robots.txt`** — explicit `Allow: /` for GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, Bytespider, CCBot. Existing `User-agent: *` `Disallow` rules unchanged.

### JSON-LD structured data (`src/schema/structured-data.ts`)
- **`organizationSchema`** — emitted from `(default)/layout.tsx` head: legal name, logo, founding date, support contact point, `sameAs` to LinkedIn / X / Facebook / Instagram / YouTube.
- **`softwareApplicationSchema`** — emitted on homepage. `applicationCategory: "BusinessApplication"`, feature highlights, `AggregateOffer` pointing at `/pricing`.
- **`buildProductSchema(region, currency, tiers)`** — emitted on pricing page. One `Offer` per tier from live Prismic data, so AI assistants can answer "how much does TutorCruncher cost in the UK?" without scraping.

Existing per-page Prismic schemas continue to work; new schemas are prepended to the same `RenderSchemas` array. `(default)/layout.tsx` `<head>` also emits `<link rel="describedby" type="application/json" href="/.well-known/ai-plugin.json" />`.

---

## Commit 2 — OpenAPI mirror, agents.json, security.txt, extra bots

- **`/.well-known/openapi.yaml` apex mirror** — Next.js rewrite proxies to `secure.tutorcruncher.com/api/schema/`. Many agent crawlers only probe the apex domain; this gets us discovered without staleness from a snapshot.
- **`/.well-known/agents.json`** (Wild Card AI 0.1.0) — declares the OpenAPI source plus ten read-only flows agents are pre-approved to invoke (`appointments_list`, `clients_list`, `invoices_list`, etc.). Mutating operations (`*_create`/`*_update`/`*_destroy`) are intentionally NOT declared as flows — they remain discoverable via OpenAPI but require explicit per-tenant consent.
- **`/.well-known/security.txt`** — Contact: `support@tutorcruncher.com`, Expires `2027-05-15`. Swap to a dedicated `security@` mailbox if/when one exists.
- **`robots.txt`** — adds explicit `Allow` for Applebot, Meta-ExternalAgent, FacebookBot, Amazonbot, cohere-ai, Diffbot, Bingbot.
- **`<link rel="alternate" type="text/plain" href="/llms.txt">`** in default layout `<head>` — gets `/llms.txt` discovered by crawlers that don't blindly probe well-known paths.

---

## Out of scope

- BreadcrumbList / FAQPage / WebSite+SearchAction / AggregateRating / Article JSON-LD — separate PR, touches Prismic-backed pages.
- MCP server — separate effort.
- OAuth 2.0 / API auth changes (the biggest remaining Ora gap, but it's an API change, not website).
- Accessibility audit (UX score 5/15) — separate follow-up.
- Solutions / feature page structured data — can be added later by editors via existing Prismic schema slots.

---

## Description for non-devs

Tells AI assistants and search-style crawlers what TutorCruncher is, where to find our API documentation, and how to read our pricing — so when someone asks one of those tools "what does TutorCruncher cost?" or "does TutorCruncher have an API?", they can give an accurate answer. Addresses the easy-wins flagged by the [Ora "Agent Readiness" report](https://ora.run/score/tutorcruncher.com) (32/100, Grade D).

---

## Test plan

- [ ] CI passes
- [ ] On staging, `curl https://tutorcruncher.com/.well-known/ai-plugin.json` — returns the manifest
- [ ] `curl -I https://tutorcruncher.com/.well-known/openapi.yaml` — returns 200 `content-type: application/yaml`, ~365 KB body
- [ ] `curl https://tutorcruncher.com/.well-known/agents.json | jq .agentsJson` — returns `"0.1.0"`
- [ ] `curl https://tutorcruncher.com/.well-known/security.txt` — returns the five-line file
- [ ] `curl https://tutorcruncher.com/llms.txt` and `/llms-full.txt` — return as plain text
- [ ] `curl https://tutorcruncher.com/robots.txt` — shows old + new AI user-agent allow rules
- [ ] View source on `/` — Organization + SoftwareApplication JSON-LD blocks, `<link rel="alternate">` to `/llms.txt`, `<link rel="describedby">` to `/.well-known/ai-plugin.json`
- [ ] View source on `/pricing/gb` — Product/Offer JSON-LD with three tiers and GBP prices
- [ ] [Google Rich Results test](https://search.google.com/test/rich-results) on `/` and `/pricing/gb` — no errors
- [ ] Re-run the Ora score at https://ora.ai/score/tutorcruncher.com — Discovery / Identity / Trust should jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)