### PR TITLE
Fix call booker showing GBP revenue brackets to non-UK visitors

### DIFF
--- a/src/components/features/booking-widget/helpers.ts
+++ b/src/components/features/booking-widget/helpers.ts
@@ -1,12 +1,21 @@
 import { COUNTRIES_CURRENCIES, LISTED_CURRENCIES } from "./constants";
 
-export const getCurrencyOptions = (countryCode: string) => {
-  let currencyStr = COUNTRIES_CURRENCIES[countryCode]?.currencies[0];
+// Resolves the currency key ("USD ($)") actually used for a country's brackets,
+// falling back to USD for countries with no listed currency.
+export const getCurrencyKeyForCountry = (countryCode: string) => {
+  const currencyStr = COUNTRIES_CURRENCIES[countryCode]?.currencies[0];
   if (!(currencyStr in LISTED_CURRENCIES)) {
-    currencyStr = COUNTRIES_CURRENCIES["US"]["currencies"][0];
+    return COUNTRIES_CURRENCIES["US"]["currencies"][0];
   }
-  return LISTED_CURRENCIES[currencyStr];
+  return currencyStr;
 };
+
+// The ISO code ("USD") for a country, matching the brackets the user was shown.
+export const getCurrencyCodeForCountry = (countryCode: string) =>
+  getCurrencyKeyForCountry(countryCode).split(" ")[0];
+
+export const getCurrencyOptions = (countryCode: string) =>
+  LISTED_CURRENCIES[getCurrencyKeyForCountry(countryCode)];
 
 export const getKeyByCurrencyCode = (currencyCode: string) => {
   for (const key in LISTED_CURRENCIES) {

--- a/src/components/features/call-booker/index.tsx
+++ b/src/components/features/call-booker/index.tsx
@@ -12,11 +12,16 @@ import { Heading } from "@/components/ui/heading";
 
 import styles from "./call-booker.module.scss";
 import { fetchAvailableSlots, getUpcomingWeekSlotDates } from "./helpers";
-import { getCurrencyOptions } from "../booking-widget/helpers";
-import { regions } from "app/data/regions/regions";
+import {
+  getCurrencyCodeForCountry,
+  getCurrencyOptions,
+} from "../booking-widget/helpers";
 import { useSearchParams } from "next/navigation";
 import { Slot } from "./types";
 import Link from "next/link";
+
+// Used only when geolocation genuinely fails, never as an initial guess.
+const FALLBACK_COUNTRY_CODE = "US";
 
 export const CallBooker = ({ rep, rb }) => {
   const [openSlots, setOpenSlots] = useState([]);
@@ -31,7 +36,10 @@ export const CallBooker = ({ rep, rb }) => {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [revenueOptions, setRevenueOptions] = useState(null);
-  const [countryCode, setCountryCode] = useState("GB");
+  const [selectedRevenue, setSelectedRevenue] = useState("");
+  // Starts null so we never render a guessed currency: showing GBP brackets to a
+  // US visitor until geolocation resolved was reported as a live bug.
+  const [countryCode, setCountryCode] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [hasLowAvailability, sethasLowAvailability] = useState(false);
 
@@ -43,6 +51,7 @@ export const CallBooker = ({ rep, rb }) => {
 
   const searchParams = useSearchParams();
   const recaptchaRef = createRef();
+  const defaultRevenueOptionIndex = +rb;
 
   useEffect(() => {
     const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -58,22 +67,34 @@ export const CallBooker = ({ rep, rb }) => {
 
   useEffect(() => {
     const getCountryCode = async () => {
-      let storedCountryCode = localStorage.getItem("_country_code");
+      const storedCountryCode = localStorage.getItem("_country_code");
 
-      if (!storedCountryCode) {
-        try {
-          const response = await fetch(
-            `${process.env.NEXT_PUBLIC_HERMES_BASE_URL}/loc/`
-          );
+      // A cached code still has to be applied to state, otherwise returning
+      // visitors were left on the initial value regardless of what was stored.
+      if (storedCountryCode) {
+        setCountryCode(storedCountryCode);
+        return;
+      }
 
-          const { country_code }: { country_code: string } =
-            await response.json();
-          storedCountryCode = country_code || "GB";
-          localStorage.setItem("_country_code", storedCountryCode);
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_HERMES_BASE_URL}/loc/`
+        );
+
+        const { country_code }: { country_code: string } =
+          await response.json();
+
+        // Only cache a real answer; caching the fallback would make a transient
+        // failure permanent for that visitor.
+        if (country_code) {
+          localStorage.setItem("_country_code", country_code);
           setCountryCode(country_code);
-        } catch (error) {
-          console.error(error);
+        } else {
+          setCountryCode(FALLBACK_COUNTRY_CODE);
         }
+      } catch (error) {
+        console.error(error);
+        setCountryCode(FALLBACK_COUNTRY_CODE);
       }
     };
 
@@ -115,8 +136,17 @@ export const CallBooker = ({ rep, rb }) => {
   }, [isExpress, rep.hermes_admin_id]);
 
   useEffect(() => {
-    setRevenueOptions(getCurrencyOptions(countryCode));
-  }, [countryCode]);
+    if (!countryCode) return;
+    const options = getCurrencyOptions(countryCode);
+    setRevenueOptions(options);
+
+    // Clamp the ?rb= index: currencies have differing bracket counts (EUR has
+    // five, the rest six), so an out-of-range index would select nothing.
+    const requestedIndex = Number.isInteger(defaultRevenueOptionIndex)
+      ? Math.min(Math.max(defaultRevenueOptionIndex, 0), options.length - 1)
+      : 0;
+    setSelectedRevenue(options[requestedIndex]?.[1] ?? "");
+  }, [countryCode, defaultRevenueOptionIndex]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
@@ -132,9 +162,6 @@ export const CallBooker = ({ rep, rb }) => {
     setIsLoading(true);
 
     const formData = new FormData(event.target as HTMLFormElement);
-    const region = regions.find(
-      (region) => region.region_code === countryCode.toLowerCase()
-    );
 
     const estimatedIncome = formData.get("revenue");
     const pricePlan = revenueOptions.find(
@@ -156,7 +183,7 @@ export const CallBooker = ({ rep, rb }) => {
       call_type: callType,
       company_name: formData.get("company"),
       country: countryCode,
-      currency: region.currency_code,
+      currency: getCurrencyCodeForCountry(countryCode),
       email: formData.get("email"),
       estimated_income: estimatedIncome,
       meeting_dt: formData.get("selected-time"),
@@ -201,8 +228,6 @@ export const CallBooker = ({ rep, rb }) => {
       setIsLoading(false);
     }
   };
-  const defaultRevenueOptionIndex = +rb;
-
   if (isSubmitted) {
     return (
       <div className={clsx(styles.bookWidget)}>
@@ -395,15 +420,20 @@ export const CallBooker = ({ rep, rb }) => {
             <select
               id="revenue"
               name="revenue"
-              defaultValue={
-                revenueOptions?.[defaultRevenueOptionIndex]?.[1] || ""
-              }
+              required
+              disabled={!revenueOptions}
+              value={selectedRevenue}
+              onChange={(e) => setSelectedRevenue(e.target.value)}
             >
-              {revenueOptions?.map(([, label]) => (
-                <option value={label} key={`revenue-option-${label}`}>
-                  {label}
-                </option>
-              ))}
+              {revenueOptions ? (
+                revenueOptions.map(([, label]) => (
+                  <option value={label} key={`revenue-option-${label}`}>
+                    {label}
+                  </option>
+                ))
+              ) : (
+                <option value="">Loading…</option>
+              )}
             </select>
             <ReCAPTCHA
               ref={recaptchaRef}


### PR DESCRIPTION
## Problem

A US customer reported the annual revenue field on the call booker:

The `CallBooker` component initialised `countryCode` to `"GB"` and only corrected itself once the async `/loc/` geolocation lookup resolved. The revenue dropdown is populated from that value, so **every visitor worldwide saw GBP brackets on first paint**, regardless of location.

Reproduced on `master` by stubbing `/loc/` to return `US`: the dropdown rendered `£0 - £50,000` with 6 GBP brackets — exactly what the customer described.

It could also stick on GBP rather than self-correcting, because a cached `_country_code` was never applied to state (the `if (!storedCountryCode)` branch skipped entirely when a value was cached), and a failed `/loc/` call left the `"GB"` default in place.

## Changes

`countryCode` now starts `null` and the dropdown renders **disabled with "Loading…"** until geolocation resolves, so no guessed currency is ever displayed.

Also fixed along the way:

- **Cached country code is now applied to state.** Returning visitors previously stayed on the initial value regardless of what was stored.
- **The fallback is no longer cached.** A transient `/loc/` failure used to write `"GB"` to `localStorage` permanently.
- **`?rb=` index is clamped.** EUR has five brackets where other currencies have six, so `rb=5` selected nothing for European visitors.
- **Submitted currency now derives from the same source as the displayed brackets**, so the two cannot disagree.

## Incidental crash fix

The old submit path did `regions.find(...)` then read `region.currency_code`, but `regions` only contains `au/ca/eu/gb/us` while the country list covers ~200 countries. Any visitor outside those five hit `undefined.currency_code` and got "Sorry something went wrong" on submit. **This may be losing bookings today — worth checking Sentry.**

## Testing

Reproduced the bug on `master` first, then verified the fix in a real browser (Playwright) by stubbing `/loc/` per scenario:

| Scenario | Result |
|---|---|
| US visitor | `$0 - $50,000`, 6 USD brackets |
| GB visitor | `£0 - £50,000`, 6 GBP brackets |
| IE visitor | `€0 - €10,000`, 5 EUR brackets |
| NZ (unlisted currency) | falls back to USD |
| Empty `country_code` | USD, not cached |
| `/loc/` network failure | USD, not cached |

End-to-end submissions send `currency=USD` with `$` income for US and `currency=EUR` with `€` income for IE, with `price_plan` mapping correctly. Out-of-range `rb=5` clamps to EUR's last bracket instead of selecting nothing.

15 unit assertions over the currency helpers also pass, covering symbol/code agreement across `US/GB/AU/CA/IE/ZA/NZ/JP`.

`next lint` and `tsc --noEmit` are both clean.

## Notes for the reviewer

- **Fixed client-side rather than server-side.** Reading the Cloudflare country header at request time would remove the loading state entirely, but `book-a-call/[uid]` uses `generateStaticParams`, so that would force all rep pages dynamic. Happy to make that trade if preferred.
- **Unrelated local issue:** `NEXT_PUBLIC_RECAPTCHA_KEY` is empty in the local `.env`, which crashes the booking form's error boundary on mount. Worked around during testing; not touched in this PR. Worth confirming it is set in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)