### PR TITLE
Redirect US visitors from the homepage to /us

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Sends visitors geolocated to the US from the UK homepage to /us.
+ *
+ * Only the homepage is redirected: /us is the sole US-specific page, so there
+ * is nowhere to send anyone browsing /pricing, /features/* or the blog.
+ *
+ * The redirect is 307 (temporary) rather than 308. A permanent redirect would
+ * tell search engines the UK homepage had moved to /us, which is the opposite
+ * of what the regional setup wants — REGIONAL_ALTERNATES in src/schema/meta.ts
+ * deliberately keeps both URLs indexed as reciprocal hreflang alternates, each
+ * with its own self-referencing canonical.
+ */
+
+/**
+ * Search and AI crawlers are never redirected.
+ *
+ * This is load-bearing for SEO, not an optimisation. Googlebot crawls almost
+ * entirely from US IP addresses, so without this exclusion every crawl of the
+ * UK homepage would bounce to /us and the UK page would drop out of the index
+ * — taking the hreflang pairing down with it, since hreflang requires both
+ * pages to be independently crawlable.
+ *
+ * Matched case-insensitively as a substring of the User-Agent. The list covers
+ * the same crawlers public/robots.txt calls out by name.
+ */
+const CRAWLER_UA_PATTERNS = [
+  "googlebot",
+  "google-inspectiontool",
+  "bingbot",
+  "slurp",
+  "duckduckbot",
+  "baiduspider",
+  "yandexbot",
+  "applebot",
+  "gptbot",
+  "chatgpt-user",
+  "oai-searchbot",
+  "claudebot",
+  "claude-web",
+  "anthropic-ai",
+  "perplexitybot",
+  "perplexity-user",
+  "facebookexternalhit",
+  "twitterbot",
+  "linkedinbot",
+  "slackbot",
+];
+
+const isCrawler = (userAgent: string) => {
+  const ua = userAgent.toLowerCase();
+  return CRAWLER_UA_PATTERNS.some((pattern) => ua.includes(pattern));
+};
+
+export function middleware(request: NextRequest) {
+  // Netlify populates `geo` by packaging this middleware into an Edge
+  // Function. Two cases leave it undefined:
+  //   - local `next dev`, where there is no edge layer at all
+  //   - production with NEXT_DISABLE_NETLIFY_EDGE=true, which drops the
+  //     middleware to a regular Netlify Function; those have no geo data
+  // In both, the redirect silently never fires and every visitor gets the UK
+  // homepage. That is the right fallback for an unknown location, but it also
+  // means enabling that env var would disable this redirect with no error. If
+  // this ever appears "broken" in production, check that flag first.
+  //
+  // Because geo is unavailable locally, `x-debug-country` allows the redirect
+  // to be exercised in development:
+  //   curl -I -H "x-debug-country: US" http://localhost:8004/
+  // The NODE_ENV guard means the header is inert in production — a visitor
+  // cannot send it to force themselves onto /us, and it cannot spoof geo on
+  // the live site.
+  const country =
+    process.env.NODE_ENV === "development"
+      ? request.headers.get("x-debug-country") ?? request.geo?.country
+      : request.geo?.country;
+
+  if (country !== "US") {
+    return NextResponse.next();
+  }
+
+  if (isCrawler(request.headers.get("user-agent") ?? "")) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = "/us";
+
+  // 307 preserves the request method and, crucially, is non-permanent — see
+  // the note above about keeping the UK homepage indexed.
+  return NextResponse.redirect(url, 307);
+}
+
+export const config = {
+  // Only the homepage. Static assets, /api, images and the /us page itself are
+  // all outside this matcher, so the middleware never runs for them — which
+  // also means no chance of a redirect loop on /us.
+  matcher: "/",
+};


### PR DESCRIPTION
`/us` has been live since #94, but nothing ever routed anyone to it — US visitors landing on tutorcruncher.com just stayed on the UK homepage.

This adds `src/middleware.ts` to redirect visitors geolocated to the US from `/` to `/us`.

## Decisions worth reviewing

**307, not 308.** A permanent redirect would tell search engines the UK homepage had moved to `/us`, which is the opposite of what #94 set up: `REGIONAL_ALTERNATES` deliberately keeps both URLs indexed as reciprocal hreflang alternates, each with its own self-referencing canonical.

**Homepage only.** `/us` is the sole US-specific page, so someone browsing `/pricing` or `/features/*` has no US equivalent to be sent to. The matcher is `"/"`, which also means the middleware never runs for `/us`, static assets or `/api` — so there is no loop risk.

**Crawlers are excluded — please sanity-check this one.** It wasn't in the original ask, but it's load-bearing rather than polish: Googlebot crawls almost entirely from US IPs, so without the exclusion every crawl of the UK homepage would bounce to `/us`, dropping it from the index and breaking the hreflang pairing (which requires both pages to be independently crawlable). The UA list mirrors the crawlers `public/robots.txt` already names.

**No opt-out for US visitors.** As specified, every US visit to `/` redirects, so there is no way to reach the UK homepage from a US IP. Flagging it as the most likely source of support complaints; adding a cookie-based opt-out later is ~10 lines.

## Verification

Geo is unavailable off-edge, so a `NODE_ENV === "development"` guarded `x-debug-country` header exercises the branches locally. It is inert in production — visitors can't use it to force themselves onto `/us` or spoof geo.

| Case | Result |
|---|---|
| US → `/` | 307 → `/us`, single hop |
| UK / unknown → `/` | 200, UK homepage |
| Googlebot from US → `/` | 200, not redirected |
| US → `/us` | 200, no loop |
| `/pricing`, `/features`, `/reviews` from US | 200, untouched |
| `/?utm_source=…` | params preserved (UTM attribution intact) |

`tsc --noEmit` and `eslint` pass.

## Before merging

Confirm **`NEXT_DISABLE_NETLIFY_EDGE` is not set to `true`** in Netlify's env vars. `request.geo` is populated by Netlify packaging middleware into an Edge Function; that flag drops it to a regular function with no geo data, which would silently disable this redirect — no error, just nothing happening. I couldn't verify that from local.

Worth testing on the deploy preview from a US IP (or via VPN) before merge, since the redirect cannot fire locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)