### PR TITLE
Add newsletter signup link to footer and blog popup

### DIFF
--- a/src/app/(default)/blog/layout.tsx
+++ b/src/app/(default)/blog/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from "react";
+
+import { NewsletterSignupPopup } from "@/components/features/newsletter-signup-popup";
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      {children}
+      <NewsletterSignupPopup />
+    </>
+  );
+}

--- a/src/components/cookie-consent-banner/index.tsx
+++ b/src/components/cookie-consent-banner/index.tsx
@@ -13,6 +13,10 @@ const REQUIRED_COOKIES = [
   "_gat_enquirytcs=",
   "cookieControlPrefs=",
   "cookieControl=",
+  // Dismissal flags for our own popups — functional, not tracking. Without
+  // these the popups reappear for anyone who declines analytics.
+  "bobbinSignupPopup=",
+  "newsletterSignupPopup=",
 ];
 
 const CookieConsentBanner = () => {

--- a/src/components/features/articles/newsletter/index.tsx
+++ b/src/components/features/articles/newsletter/index.tsx
@@ -1,109 +1,18 @@
- /* eslint-disable */ 
+ /* eslint-disable */
  "use client";
 
-import { useState, FormEvent } from "react";
 import { Heading } from "@/components/ui/heading";
-import { Action } from "@/components/ui/action";
+import { NewsletterForm } from "./newsletter-form";
 import styles from "./newsletter.module.scss";
 
-const MAILCHIMP_POST_URL =
-  "https://tutorcruncher.us13.list-manage.com/subscribe/post-json?u=ea12d2871ca6b988ff70c3dbe&id=492dd26d91&v_id=5416&f_id=00b5d7ecf0";
-
-export const Newsletter = () => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsLoading(true);
-    setErrorMessage("");
-
-    const formData = new FormData(e.currentTarget);
-    const params = new URLSearchParams();
-    formData.forEach((value, key) => {
-      params.set(key, value as string);
-    });
-
-    const callbackName = `mc_resp_${Date.now()}`;
-    const url = `${MAILCHIMP_POST_URL}&${params.toString()}&c=${callbackName}`;
-
-    (window as any)[callbackName] = (data: { result: string; msg: string }) => {
-      if (data.result === "success") {
-        setIsSubmitted(true);
-      } else {
-        const msg = data.msg || "Something went wrong. Please try again.";
-        setErrorMessage(msg.includes("already subscribed")
-          ? "You are already subscribed!"
-          : msg.replace(/<a [^>]+>[^<]+<\/a>/, "").trim()
-        );
-      }
-      setIsLoading(false);
-      delete (window as any)[callbackName];
-      script.remove();
-    };
-
-    const script = document.createElement("script");
-    script.src = url;
-    script.onerror = () => {
-      setErrorMessage("Something went wrong. Please try again.");
-      setIsLoading(false);
-      delete (window as any)[callbackName];
-      script.remove();
-    };
-    document.body.appendChild(script);
-  };
-
-  return (
-    <div className={styles.newsletter}>
-      <Heading size="xsmall" variant="h2" noMargin>
-        Stay in the loop
-      </Heading>
-      <p>
-        Sign up to our mailing list to get monthly updates and insights straight to your inbox.
-      </p>
-      <form onSubmit={handleSubmit}>
-        <input type="hidden" name="tags" value="7236437" />
-        <div style={{ position: "absolute", left: "-5000px" }} aria-hidden="true">
-          <input
-            type="text"
-            name="b_ea12d2871ca6b988ff70c3dbe_492dd26d91"
-            tabIndex={-1}
-            defaultValue=""
-          />
-        </div>
-        <input
-          type="email"
-          name="EMAIL"
-          placeholder="Email"
-          required
-          disabled={isLoading || isSubmitted}
-          className={styles.input}
-        />
-        <fieldset className={styles.gdpr}>
-          <label className={styles.consent}>
-            <input type="checkbox" name="gdpr[71425]" value="Y" disabled={isLoading || isSubmitted} checked />
-            <span>Email marketing</span>
-          </label>
-          {isSubmitted ? (
-            <>
-            <p className={styles.successMessage}>Thank you for subscribing!</p>
-            <p>You can unsubscribe at anytime by clicking the link in the footer of our emails.</p>
-            </>
-          ) : (
-            <>
-            <Action disableAnimation type="submit" disabled={isLoading} loading={isLoading}>
-              Subscribe
-            </Action>
-             <p className={styles.legalText}>
-            By signing up to our newsletter you consent to receive marketing communications from TutorCruncher.
-          </p>
-          </>
-          )}
-          {errorMessage && <p className={styles.errorMessage}>{errorMessage}</p>}
-         
-        </fieldset>
-      </form>
-    </div>
-  );
-};
+export const Newsletter = () => (
+  <div className={styles.newsletter}>
+    <Heading size="xsmall" variant="h2" noMargin>
+      Stay in the loop
+    </Heading>
+    <p>
+      Sign up to our mailing list to get monthly updates and insights straight to your inbox.
+    </p>
+    <NewsletterForm />
+  </div>
+);

--- a/src/components/features/articles/newsletter/newsletter-form.tsx
+++ b/src/components/features/articles/newsletter/newsletter-form.tsx
@@ -1,0 +1,105 @@
+ /* eslint-disable */
+ "use client";
+
+import { useState, FormEvent } from "react";
+import { Action } from "@/components/ui/action";
+import styles from "./newsletter.module.scss";
+
+const MAILCHIMP_POST_URL =
+  "https://tutorcruncher.us13.list-manage.com/subscribe/post-json?u=ea12d2871ca6b988ff70c3dbe&id=492dd26d91&v_id=5416&f_id=00b5d7ecf0";
+
+interface NewsletterFormProps {
+  onSuccess?: () => void;
+}
+
+export const NewsletterForm = ({ onSuccess }: NewsletterFormProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsLoading(true);
+    setErrorMessage("");
+
+    const formData = new FormData(e.currentTarget);
+    const params = new URLSearchParams();
+    formData.forEach((value, key) => {
+      params.set(key, value as string);
+    });
+
+    const callbackName = `mc_resp_${Date.now()}`;
+    const url = `${MAILCHIMP_POST_URL}&${params.toString()}&c=${callbackName}`;
+
+    (window as any)[callbackName] = (data: { result: string; msg: string }) => {
+      if (data.result === "success") {
+        setIsSubmitted(true);
+        onSuccess?.();
+      } else {
+        const msg = data.msg || "Something went wrong. Please try again.";
+        setErrorMessage(msg.includes("already subscribed")
+          ? "You are already subscribed!"
+          : msg.replace(/<a [^>]+>[^<]+<\/a>/, "").trim()
+        );
+      }
+      setIsLoading(false);
+      delete (window as any)[callbackName];
+      script.remove();
+    };
+
+    const script = document.createElement("script");
+    script.src = url;
+    script.onerror = () => {
+      setErrorMessage("Something went wrong. Please try again.");
+      setIsLoading(false);
+      delete (window as any)[callbackName];
+      script.remove();
+    };
+    document.body.appendChild(script);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input type="hidden" name="tags" value="7236437" />
+      <div style={{ position: "absolute", left: "-5000px" }} aria-hidden="true">
+        <input
+          type="text"
+          name="b_ea12d2871ca6b988ff70c3dbe_492dd26d91"
+          tabIndex={-1}
+          defaultValue=""
+        />
+      </div>
+      <input
+        type="email"
+        name="EMAIL"
+        placeholder="Email"
+        required
+        disabled={isLoading || isSubmitted}
+        className={styles.input}
+      />
+      <fieldset className={styles.gdpr}>
+        <label className={styles.consent}>
+          <input type="checkbox" name="gdpr[71425]" value="Y" disabled={isLoading || isSubmitted} checked />
+          <span>Email marketing</span>
+        </label>
+        {isSubmitted ? (
+          <>
+          <p className={styles.successMessage}>Thank you for subscribing!</p>
+          <p>You can unsubscribe at anytime by clicking the link in the footer of our emails.</p>
+          </>
+        ) : (
+          <>
+          <Action disableAnimation type="submit" disabled={isLoading} loading={isLoading}>
+            Subscribe
+          </Action>
+           <p className={styles.legalText}>
+          By signing up to our newsletter you consent to receive marketing communications from TutorCruncher.
+        </p>
+        </>
+        )}
+        {errorMessage && <p className={styles.errorMessage}>{errorMessage}</p>}
+
+      </fieldset>
+    </form>
+  );
+};

--- a/src/components/features/newsletter-signup-popup/data.ts
+++ b/src/components/features/newsletter-signup-popup/data.ts
@@ -1,0 +1,2 @@
+export const NEWSLETTER_SIGNUP_URL =
+  "https://mailchi.mp/tutorcruncher/tutorcruncher-newsletter";

--- a/src/components/features/newsletter-signup-popup/index.tsx
+++ b/src/components/features/newsletter-signup-popup/index.tsx
@@ -4,14 +4,13 @@ import { useEffect, useState } from "react";
 import cookie from "js-cookie";
 
 import { CloseSvg } from "@/svgs/close";
+import { NewsletterForm } from "@/components/features/articles/newsletter/newsletter-form";
 
-import { NEWSLETTER_SIGNUP_URL } from "./data";
 import styles from "./newsletter-signup-popup.module.scss";
 
 const COOKIE_NAME = "newsletterSignupPopup";
 const COOKIE_VALUE = "dismissed";
-const SHOW_DELAY_MS = 15000;
-const CTA_URL = `${NEWSLETTER_SIGNUP_URL}?utm_source=tutorcruncher&utm_medium=popup&utm_campaign=blog-newsletter`;
+const SHOW_DELAY_MS = 10000;
 
 const benefits = [
   "Monthly updates on what's new in TutorCruncher",
@@ -33,25 +32,6 @@ const CheckIcon = () => (
       d="M8 12.5l2.8 2.8L16.5 9.5"
       stroke="#fff"
       strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
-const ArrowRightIcon = () => (
-  <svg
-    width="20"
-    height="20"
-    viewBox="0 0 20 20"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    aria-hidden="true"
-  >
-    <path
-      d="M4 10h12m0 0l-5-5m5 5l-5 5"
-      stroke="currentColor"
-      strokeWidth="1.7"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
@@ -90,10 +70,6 @@ export const NewsletterSignupPopup = () => {
     setIsOpen(false);
   };
 
-  const handleCtaClick = () => {
-    persistDismissal();
-  };
-
   if (!isOpen) return null;
 
   return (
@@ -128,20 +104,9 @@ export const NewsletterSignupPopup = () => {
               ))}
             </ul>
           </div>
-          <a
-            href={CTA_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.cta}
-            onClick={handleCtaClick}
-          >
-            Sign up
-            <ArrowRightIcon />
-          </a>
-          <p className={styles.legalText}>
-            By signing up to our newsletter you consent to receive marketing
-            communications from TutorCruncher. You can unsubscribe at any time.
-          </p>
+          <div className={styles.form}>
+            <NewsletterForm onSuccess={persistDismissal} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/features/newsletter-signup-popup/index.tsx
+++ b/src/components/features/newsletter-signup-popup/index.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import cookie from "js-cookie";
+
+import { CloseSvg } from "@/svgs/close";
+
+import { NEWSLETTER_SIGNUP_URL } from "./data";
+import styles from "./newsletter-signup-popup.module.scss";
+
+const COOKIE_NAME = "newsletterSignupPopup";
+const COOKIE_VALUE = "dismissed";
+const SHOW_DELAY_MS = 15000;
+const CTA_URL = `${NEWSLETTER_SIGNUP_URL}?utm_source=tutorcruncher&utm_medium=popup&utm_campaign=blog-newsletter`;
+
+const benefits = [
+  "Monthly updates on what's new in TutorCruncher",
+  "Practical tips for running a tutoring business",
+  "Industry insights straight to your inbox",
+];
+
+const CheckIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="9.08" fill="currentColor" />
+    <path
+      d="M8 12.5l2.8 2.8L16.5 9.5"
+      stroke="#fff"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const ArrowRightIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+  >
+    <path
+      d="M4 10h12m0 0l-5-5m5 5l-5 5"
+      stroke="currentColor"
+      strokeWidth="1.7"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const NewsletterSignupPopup = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (cookie.get(COOKIE_NAME)) return;
+
+    const timer = setTimeout(() => setIsOpen(true), SHOW_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        persistDismissal();
+        setIsOpen(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  const persistDismissal = () => {
+    cookie.set(COOKIE_NAME, COOKIE_VALUE, { expires: 365 });
+  };
+
+  const dismiss = () => {
+    persistDismissal();
+    setIsOpen(false);
+  };
+
+  const handleCtaClick = () => {
+    persistDismissal();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={dismiss}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Newsletter signup"
+    >
+      <div className={styles.popup} onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          className={styles.close}
+          onClick={dismiss}
+          aria-label="Close"
+        >
+          <CloseSvg />
+        </button>
+        <div className={styles.content}>
+          <div className={styles.topGroup}>
+            <p className={styles.heading}>Stay in the loop</p>
+            <p className={styles.intro}>
+              Sign up to the TutorCruncher newsletter and get:
+            </p>
+            <ul className={styles.benefits}>
+              {benefits.map((benefit) => (
+                <li key={benefit}>
+                  <CheckIcon />
+                  <span>{benefit}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <a
+            href={CTA_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.cta}
+            onClick={handleCtaClick}
+          >
+            Sign up
+            <ArrowRightIcon />
+          </a>
+          <p className={styles.legalText}>
+            By signing up to our newsletter you consent to receive marketing
+            communications from TutorCruncher. You can unsubscribe at any time.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/features/newsletter-signup-popup/newsletter-signup-popup.module.scss
+++ b/src/components/features/newsletter-signup-popup/newsletter-signup-popup.module.scss
@@ -92,42 +92,33 @@
   }
 }
 
-.cta {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: grid(2);
-  width: 100%;
-  padding: 16px 24px;
-  background-color: $steel-blue;
-  color: $white;
-  border: none;
-  border-radius: 36px;
-  font-size: $font-size--base;
-  font-weight: 500;
-  text-decoration: none;
-  cursor: pointer;
-  transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+.form {
+  button {
+    margin: 0;
+    text-align: center;
+    width: 100%;
 
-  &:hover {
-    color: $white;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 0 0 rgba(54, 46, 131, 0.2);
+    svg {
+      width: 20px;
+      height: 20px;
+    }
   }
 
-  svg {
-    width: 20px;
-    height: 20px;
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: grid(3) 0 0;
   }
-}
 
-.legalText {
-  margin: 0;
-  background-color: $white;
-  padding: grid(3);
-  border-radius: $border-radius--small;
-  font-size: $font-size--small;
-  line-height: 1.4;
+  p {
+    margin-top: grid(1);
+    font-size: $font-size--small;
+    line-height: 1.4;
+  }
+
+  label {
+    display: none;
+  }
 }
 
 .close {

--- a/src/components/features/newsletter-signup-popup/newsletter-signup-popup.module.scss
+++ b/src/components/features/newsletter-signup-popup/newsletter-signup-popup.module.scss
@@ -1,0 +1,176 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: grid(4);
+  animation: fadeIn 0.2s ease-out;
+}
+
+.popup {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background-color: $baby-blue;
+  border-radius: 30px;
+  overflow: hidden;
+  width: 100%;
+  max-width: 459px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  animation: popIn 0.25s ease-out;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  @media (max-width: $sm) {
+    border-radius: 24px;
+  }
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: grid(6);
+  padding: grid(8) grid(7);
+  color: $navy-blue;
+
+  @media (max-width: $sm) {
+    padding: grid(6);
+    gap: grid(5);
+  }
+}
+
+.topGroup {
+  display: flex;
+  flex-direction: column;
+  gap: grid(4);
+}
+
+.heading {
+  margin: 0;
+  padding-right: grid(10);
+  font-size: $font-size--xlarge;
+  font-weight: 700;
+  line-height: 1.2;
+  color: $steel-blue;
+}
+
+.intro {
+  margin: 0;
+  font-size: $font-size--base;
+  line-height: 1.4;
+}
+
+.benefits {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: grid(2);
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: grid(2);
+    font-size: $font-size--base;
+    line-height: 1.3;
+  }
+
+  svg {
+    flex-shrink: 0;
+    width: 24px;
+    height: 24px;
+    color: $steel-blue;
+  }
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: grid(2);
+  width: 100%;
+  padding: 16px 24px;
+  background-color: $steel-blue;
+  color: $white;
+  border: none;
+  border-radius: 36px;
+  font-size: $font-size--base;
+  font-weight: 500;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 0.15s ease-out, box-shadow 0.15s ease-out;
+
+  &:hover {
+    color: $white;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 0 0 rgba(54, 46, 131, 0.2);
+  }
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.legalText {
+  margin: 0;
+  background-color: $white;
+  padding: grid(3);
+  border-radius: $border-radius--small;
+  font-size: $font-size--small;
+  line-height: 1.4;
+}
+
+.close {
+  position: absolute;
+  top: grid(4);
+  right: grid(4);
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  background: rgba(31, 55, 78, 0.1);
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  color: $navy-blue;
+  z-index: 2;
+
+  &:hover {
+    background: rgba(31, 55, 78, 0.2);
+  }
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes popIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { Action } from "@/components/ui/action";
+import { NEWSLETTER_SIGNUP_URL } from "@/components/features/newsletter-signup-popup/data";
 import LogoSvg from "@/svgs/logo";
 
 import { Accordion } from "./accordion";
@@ -44,6 +45,9 @@ export const Footer = async () => {
             <Accordion title="About us">
               <Link href="/about">About</Link>
               <Link href="/blog">Blog</Link>
+              <Link href={NEWSLETTER_SIGNUP_URL} target="_blank">
+                Newsletter
+              </Link>
               <Link href="/reviews">Reviews</Link>
               <Link href="/careers">Careers</Link>
               <Link href="/pricing">Pricing</Link>


### PR DESCRIPTION
Closes #104.

## What

- **Footer link** — the "About us" column now has a **Newsletter** link pointing at the Mailchimp landing page Frances set up (`mailchi.mp/tutorcruncher/tutorcruncher-newsletter`), so there's a direct link to share with people.
- **Blog popup** — a delayed, cookie-dismissed signup popup on blog pages. It appears after **10s**, can be dismissed via the close button, overlay click or Escape, and stays dismissed for 365 days.
- The popup embeds **the same signup form used on the article pages**, so visitors subscribe in place rather than being sent off to Mailchimp. Submitting successfully also sets the dismissal cookie.
- Mounted via a new `blog/layout.tsx`, so it covers the blog index, pagination, search and article pages without touching each one.

## Shared form

The Mailchimp form logic previously lived inside the article `Newsletter` block. It's been extracted to `newsletter/newsletter-form.tsx` and is now used by both the on-page block and the popup, so the two can't drift apart. `Newsletter` is now just the heading/intro wrapper around it.

The footer still links out to the Mailchimp landing page via the shared `NEWSLETTER_SIGNUP_URL` constant.

## Consent-banner fix

`clearCookies()` in the consent banner deletes every cookie not on `REQUIRED_COOKIES` when a visitor declines analytics. That would have wiped the popup's dismissal cookie and made it reappear on the next visit — the same bug already applied to the existing Bobbin popup. Both dismissal cookies are now allowlisted; they're functional, not tracking.

## Notes

- The popup is blog-only, so it won't compete with the Bobbin popup on the homepage. Two popups could still stack for a visitor who browses homepage → blog in one session; happy to gate them against each other if that's a concern.
- **Bobbin** — the "carry out this for Bobbin" comment is not covered here; that's a separate repo and PR.

## Testing

- `npm run build`, `npx tsc --noEmit` and lint all pass.
- The popup's rendered appearance with the embedded form has **not** been visually verified in a browser — worth a quick look before merge, particularly the form's spacing inside the popup's `$baby-blue` panel and the mobile (390px) layout, since the popup scrolls at `max-height: 90vh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)