### PR TITLE
Treat Google Ads click IDs (gclid/gbraid/wbraid) as paid attribution

### DIFF
--- a/src/app/providers/tracking-provider.tsx
+++ b/src/app/providers/tracking-provider.tsx
@@ -2,6 +2,7 @@
 The following comment outlines the logic for setting the tracking parameters:
 If someone comes from direct first, we assign tc_source to Direct and then overwrite it if they come from somewhere else
 If utm_source is present, then the user must have come from an ad. tc_source is set to the utm_source and tc_campaign is set to utm_campaign. This is then never changed
+If there is no utm_source but the URL has a Google Ads click ID (gclid/gbraid/wbraid, e.g. Performance Max), the user also came from an ad: tc_source is set to google
 If utm_source is not present, we set tc_source from the referrer unless tc_source has already been set as a cookie and tc_source is not Direct. tc_campaign should be set to tc-[page-type]-[page-title-slugified] which is based off of the landing page
 */
 
@@ -138,6 +139,24 @@ const getTrackingParams = (): Record<string, string> => {
 
     params.tc_source = utmSource;
     if (utmCampaign) params.tc_campaign = utmCampaign;
+    return params;
+  }
+
+  // Google Ads auto-tagging (Performance Max in particular) lands with a
+  // gclid/gbraid/wbraid but no UTM parameters, so the referrer logic below
+  // would label the visit organic (google.com). A click ID in the URL means a
+  // paid Google click, so label it like a utm_source=google ad click.
+  const freshClickId =
+    (gclidParam && isGclsrcValid ? gclidParam : null) ||
+    urlParams.get("gbraid") ||
+    urlParams.get("wbraid");
+  if (freshClickId) {
+    const campaign = storedCampaign || getPageInfo();
+    localStorage.setItem("_tc_source", "google");
+    localStorage.setItem("_tc_campaign", campaign);
+
+    params.tc_source = "google";
+    params.tc_campaign = campaign;
     return params;
   }
 


### PR DESCRIPTION
## Summary
Performance Max ads land with a `gclid` but no UTM parameters, so the referrer fallback in the tracking provider labelled those visits organic (`tc_source=google.com`). Reconciling signups against the raw GA4 export (28 May – 1 Aug) showed 23 of 88 signups we attributed to `google.com` were actually Cross-network (PMax) or Paid Search per GA4 — ~26% of our "organic google" signups.

## What we did
- If the landing URL carries a Google Ads click ID (`gclid` validated via `gclsrc`, or `gbraid`/`wbraid`) and no `utm_source`, set `tc_source=google` and persist it, exactly like a UTM-tagged ad click.
- The new branch runs before the regional landing-page branch, so a paid click on `/us` keeps paid attribution.
- `tc_campaign` keeps any stored campaign, otherwise falls back to the existing page-based value (no campaign name is available from a click ID alone).

Related: tutorcruncher/tutorcruncher-website#107, tutorcruncher/TutorCruncher2#17398, tutorcruncher/hermes#410

🤖 Generated with [Claude Code](https://claude.com/claude-code)